### PR TITLE
backport curl_multi_wait fixes for radosgw

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -803,7 +803,7 @@ CURLMcode curl_multi_wait(CURLM *multi_handle,
   struct Curl_one_easy *easy;
   curl_socket_t sockbunch[MAX_SOCKSPEREASYHANDLE];
   int bitmap;
-  unsigned int i;
+  unsigned int i, j;
   unsigned int nfds = 0;
   unsigned int curlfds;
   struct pollfd *ufds = NULL;
@@ -904,6 +904,9 @@ CURLMcode curl_multi_wait(CURLM *multi_handle,
     i = Curl_poll(ufds, nfds, timeout_ms);
   else
     i = 0;
+
+  for(j = nfds - extra_nfds; j < nfds; j++)
+    extra_fds[j].revents = ufds[j].revents;
 
   Curl_safefree(ufds);
   if(ret)

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -803,7 +803,7 @@ CURLMcode curl_multi_wait(CURLM *multi_handle,
   struct Curl_one_easy *easy;
   curl_socket_t sockbunch[MAX_SOCKSPEREASYHANDLE];
   int bitmap;
-  unsigned int i, j;
+  unsigned int i;
   unsigned int nfds = 0;
   unsigned int curlfds;
   struct pollfd *ufds = NULL;
@@ -899,14 +899,32 @@ CURLMcode curl_multi_wait(CURLM *multi_handle,
     ++nfds;
   }
 
-  if(nfds)
+  if(nfds) {
     /* wait... */
     i = Curl_poll(ufds, nfds, timeout_ms);
+
+    if(i) {
+      unsigned int j;
+      /* copy revents results from the poll to the curl_multi_wait poll
+         struct, the bit values of the actual underlying poll() implementation
+         may not be the same as the ones in the public libcurl API! */
+      for(j = 0; j < extra_nfds; j++) {
+        unsigned short mask = 0;
+        unsigned r = ufds[curlfds + j].revents;
+
+        if(r & POLLIN)
+          mask |= CURL_WAIT_POLLIN;
+        if(r & POLLOUT)
+          mask |= CURL_WAIT_POLLOUT;
+        if(r & POLLPRI)
+          mask |= CURL_WAIT_POLLPRI;
+
+        extra_fds[j].revents = mask;
+      }
+    }
+  }
   else
     i = 0;
-
-  for(j = nfds - extra_nfds; j < nfds; j++)
-    extra_fds[j].revents = ufds[j].revents;
 
   Curl_safefree(ufds);
   if(ret)

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -804,7 +804,8 @@ CURLMcode curl_multi_wait(CURLM *multi_handle,
   curl_socket_t sockbunch[MAX_SOCKSPEREASYHANDLE];
   int bitmap;
   unsigned int i;
-  unsigned int nfds = extra_nfds;
+  unsigned int nfds = 0;
+  unsigned int curlfds;
   struct pollfd *ufds = NULL;
   long timeout_internal;
 
@@ -842,6 +843,9 @@ CURLMcode curl_multi_wait(CURLM *multi_handle,
     easy = easy->next; /* check next handle */
   }
 
+  curlfds = nfds; /* number of internal file descriptors */
+  nfds += extra_nfds; /* add the externally provided ones */
+
   if(nfds) {
     ufds = malloc(nfds * sizeof(struct pollfd));
     if(!ufds)
@@ -849,32 +853,37 @@ CURLMcode curl_multi_wait(CURLM *multi_handle,
   }
   nfds = 0;
 
-  /* Add the curl handles to our pollfds first */
-  easy=multi->easy.next;
-  while(easy != &multi->easy) {
-    bitmap = multi_getsock(easy, sockbunch, MAX_SOCKSPEREASYHANDLE);
+  /* only do the second loop if we found descriptors in the first stage run
+     above */
 
-    for(i=0; i< MAX_SOCKSPEREASYHANDLE; i++) {
-      curl_socket_t s = CURL_SOCKET_BAD;
+  if(curlfds) {
+    /* Add the curl handles to our pollfds first */
+    easy=multi->easy.next;
+    while(easy != &multi->easy) {
+      bitmap = multi_getsock(easy, sockbunch, MAX_SOCKSPEREASYHANDLE);
 
-      if(bitmap & GETSOCK_READSOCK(i)) {
-        ufds[nfds].fd = sockbunch[i];
-        ufds[nfds].events = POLLIN;
-        ++nfds;
-        s = sockbunch[i];
+      for(i=0; i< MAX_SOCKSPEREASYHANDLE; i++) {
+        curl_socket_t s = CURL_SOCKET_BAD;
+
+        if(bitmap & GETSOCK_READSOCK(i)) {
+          ufds[nfds].fd = sockbunch[i];
+          ufds[nfds].events = POLLIN;
+          ++nfds;
+          s = sockbunch[i];
+        }
+        if(bitmap & GETSOCK_WRITESOCK(i)) {
+          ufds[nfds].fd = sockbunch[i];
+          ufds[nfds].events = POLLOUT;
+          ++nfds;
+          s = sockbunch[i];
+        }
+        if(s == CURL_SOCKET_BAD) {
+          break;
+        }
       }
-      if(bitmap & GETSOCK_WRITESOCK(i)) {
-        ufds[nfds].fd = sockbunch[i];
-        ufds[nfds].events = POLLOUT;
-        ++nfds;
-        s = sockbunch[i];
-      }
-      if(s == CURL_SOCKET_BAD) {
-        break;
-      }
+
+      easy = easy->next; /* check next handle */
     }
-
-    easy = easy->next; /* check next handle */
   }
 
   /* Add external file descriptions from poll-like struct curl_waitfd */


### PR DESCRIPTION
When using libcurl.so built from rhel-7.2-patches, unit test for RGWHTTPManager deadlocks consistently:

```
~/ceph/build $ LD_PRELOAD=~/local/lib/libcurl.so bin/unittest_http_manager                                                                    
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from HTTPManager
[ RUN      ] HTTPManager.SignalThread
^C
```

When using libcurl.so built from this branch, test passes consistently:

```
~/ceph/build $ LD_PRELOAD=~/local/lib/libcurl.so bin/unittest_http_manager --gtest_repeat=1000
...
Repeating all tests (iteration 1000) . . .

[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from HTTPManager
[ RUN      ] HTTPManager.SignalThread
[       OK ] HTTPManager.SignalThread (75 ms)
[----------] 1 test from HTTPManager (75 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (75 ms total)
[  PASSED  ] 1 test.
```
